### PR TITLE
Fix for python3.9

### DIFF
--- a/pytchat/core/pytchat.py
+++ b/pytchat/core/pytchat.py
@@ -168,7 +168,7 @@ class PytchatCore:
             with httpx.Client(http2=True) as client:
                 try:
                     response = client.post(self._fetch_url, json=param)
-                    livechat_json = json.loads(response.text, encoding='utf-8')
+                    livechat_json = json.loads(response.text)
                     break
                 except (json.JSONDecodeError, httpx.ConnectTimeout, httpx.ReadTimeout, httpx.ConnectError) as e:
                     err = e


### PR DESCRIPTION
'encoding' is deprecated and removed in Python 3.9 
could fix this https://github.com/taizan-hokuto/pytchat/issues/24